### PR TITLE
Implement External Navigation API via REST

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -115,10 +115,28 @@ def api_state():
     engine = get_engine()
     return jsonify(_get_state_payload(engine))
 
+@app.route('/api/action/move', methods=['POST'])
+def api_action_move():
+    """Trigger the core engine iterator to navigate forward or backwards."""
+    data = request.json or {}
+    direction = data.get('direction')
+    
+    engine = get_engine()
+    if direction == 'right' or direction == 'next':
+        engine.next_fixation()
+    elif direction == 'left' or direction == 'previous':
+        engine.previous_fixation()
+        
+    return jsonify({
+        "message": f"Moved {direction}",
+        "state": _get_state_payload(engine)
+    })
+
 # Helper to format state for JSON
 def _get_state_payload(engine):
     payload = {
         "has_data": engine.eye_events is not None and not engine.eye_events.empty,
+        "current_fixation": engine.current_fixation,
         "fixations": [],
         "saccades": [] # Could be computed here or on frontend
     }


### PR DESCRIPTION
Closes #22. I exposed the `previous_fixation` and `next_fixation` properties over the network via `/api/action/move` to allow external frontend clients to command the cursor.