### PR TITLE
Implement Manual Fixation Correction REST API

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -64,6 +64,22 @@ class Fix8Core:
         if self.current_fixation < len(self.eye_events) - 1:
             self.current_fixation += 1
 
+    def update_fixation(self, index: int, new_x: float, new_y: float):
+        """Manually corrects the position of a specific fixation."""
+        if self.eye_events is None or self.eye_events.empty:
+            return
+            
+        # Get the dataframe index for the Nth fixation
+        fixations_only = self.eye_events[self.eye_events['eye_event'] == 'fixation']
+        if index < 0 or index >= len(fixations_only):
+            return
+            
+        real_df_index = fixations_only.index[index]
+        
+        # Overwrite coordinates
+        self.eye_events.at[real_df_index, 'x_cord'] = new_x
+        self.eye_events.at[real_df_index, 'y_cord'] = new_y
+
     def save_state(self):
         """Saves current state to history for undo functionality."""
         current_state = Fix8State(

--- a/web/app.py
+++ b/web/app.py
@@ -132,6 +132,28 @@ def api_action_move():
         "state": _get_state_payload(engine)
     })
 
+@app.route('/api/action/update_fixation', methods=['POST'])
+def api_update_fixation():
+    """Manual correction: updating a specific fixation's coordinates."""
+    data = request.json or {}
+    index = data.get('index')
+    x = data.get('x')
+    y = data.get('y')
+    
+    if index is None or x is None or y is None:
+        return jsonify({"error": "Missing required fields (index, x, y)"}), 400
+        
+    engine = get_engine()
+    
+    try:
+        engine.update_fixation(int(index), float(x), float(y))
+        return jsonify({
+            "message": f"Fixation {index} updated to ({x}, {y})",
+            "state": _get_state_payload(engine)
+        })
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
 # Helper to format state for JSON
 def _get_state_payload(engine):
     payload = {


### PR DESCRIPTION
Closes #26. I developed the `update_fixation` mathematical routine within `Fix8Core` to safely rewrite specific node coordinates in the Pandas dataframe. I then exposed this capability globally via the `/api/action/update_fixation` endpoint so arbitrary frontend elements can correct tracking drift.