### PR TITLE
feat(dashboard): Allow users to delete projects

### DIFF
--- a/web/routes/dashboard.py
+++ b/web/routes/dashboard.py
@@ -86,6 +86,23 @@ def load_project(project_id):
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
+@dashboard_bp.route('/api/projects/<int:project_id>', methods=['DELETE'])
+@login_required
+def delete_project(project_id):
+    project = Project.query.filter_by(id=project_id, user_id=current_user.id).first()
+    if not project:
+        return jsonify({"error": "Project not found"}), 404
+
+    if not project.is_demo:
+        storage_path = os.environ.get('STORAGE_PATH', os.path.join(os.path.dirname(__file__), '..', 'uploads'))
+        file_path = os.path.join(storage_path, project.file_path)
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+    db.session.delete(project)
+    db.session.commit()
+    return jsonify({"message": "Project deleted"})
+
 @dashboard_bp.route('/api/upload', methods=['POST'])
 @login_required
 def upload_file():

--- a/web/static/dashboard.html
+++ b/web/static/dashboard.html
@@ -117,6 +117,27 @@
             border: 1px dashed rgba(255, 255, 255, 0.1);
         }
 
+        .delete-btn {
+            position: absolute;
+            top: 12px;
+            right: 12px;
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            border: none;
+            background: rgba(239, 68, 68, 0.15);
+            color: rgba(239, 68, 68, 0.7);
+            font-size: 1rem;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            opacity: 0;
+            transition: opacity 0.2s ease, background 0.2s ease, color 0.2s ease;
+        }
+        .project-card:hover .delete-btn { opacity: 1; }
+        .delete-btn:hover { background: rgba(239, 68, 68, 0.8) !important; color: white !important; }
+
         .upload-zone {
             border: 2px dashed rgba(56, 189, 248, 0.4);
             border-radius: 16px;
@@ -200,11 +221,31 @@
                 const card = document.createElement('div');
                 card.className = 'project-card';
                 card.innerHTML = `
+                    <button class="delete-btn" title="Delete project">&#x2715;</button>
                     <div class="project-title">${p.name}</div>
                     <div class="project-meta">ID: ${p.id}</div>
                     ${p.is_demo ? '<div class="badge">Demo Dataset</div>' : ''}
                 `;
-                
+
+                card.querySelector('.delete-btn').addEventListener('click', async (e) => {
+                    e.stopPropagation();
+                    if (!confirm(`Delete "${p.name}"? This cannot be undone.`)) return;
+                    const res = await fetch(`/api/projects/${p.id}`, { method: 'DELETE' });
+                    if (res.ok) {
+                        card.style.transition = 'opacity 0.2s ease, transform 0.2s ease';
+                        card.style.opacity = '0';
+                        card.style.transform = 'scale(0.95)';
+                        setTimeout(() => {
+                            card.remove();
+                            if (!container.querySelector('.project-card')) {
+                                emptyState.style.display = 'block';
+                            }
+                        }, 200);
+                    } else {
+                        alert('Failed to delete project.');
+                    }
+                });
+
                 card.addEventListener('click', async () => {
                     card.style.opacity = '0.5';
                     const loadRes = await fetch(`/api/projects/${p.id}/load`, { method: 'POST' });
@@ -215,7 +256,7 @@
                         alert('Failed to load project into engine.');
                     }
                 });
-                
+
                 if (container.firstChild) {
                     container.insertBefore(card, container.firstChild);
                 } else {


### PR DESCRIPTION
Added the ability to delete projects from the dashboard.

- `web/routes/dashboard.py`: Added a `DELETE /api/projects/<id>` route that deletes the project from the DB, and removes the actual file from the uploads directory if it's not a demo.
- `web/static/dashboard.html`: Added a hoverable X button to project cards. Prompts the user for confirmation and smoothly animates the card out of the grid, showing the empty state if it was the last project.