### PR TITLE
fix: invert y-axis when no stimulus image is loaded

### DIFF
--- a/web/routes/api.py
+++ b/web/routes/api.py
@@ -526,6 +526,8 @@ def api_render():
     fig, ax = plt.subplots(figsize=(fig_width, fig_height), dpi=100)
     if img is not None:
         ax.imshow(img)
+    else:
+        ax.invert_yaxis()
 
     if show_aois and engine.aoi is not None and not engine.aoi.empty:
         for _, row in engine.aoi.iterrows():


### PR DESCRIPTION
Fixes the y-axis coordinate system mismatch. When no stimulus image is loaded, Matplotlib uses mathematical coordinates (y=0 at bottom), causing fixations to render upside-down. This adds `ax.invert_yaxis()` when no image is present to match screen coordinates (y=0 at top) so fixations are correctly positioned regardless of the background.