### PR TITLE
feat: Pair stimulus images with projects

### DIFF
--- a/web/__init__.py
+++ b/web/__init__.py
@@ -44,10 +44,10 @@ def create_app():
     @login_manager.user_loader
     def load_user(user_id):
         return User.query.get(int(user_id))
-
     # Initialize DB tables
     with app.app_context():
         db.create_all()
+        _run_migrations(app)
 
     # Route: Static File Entrypoint
     from flask_login import current_user
@@ -68,3 +68,16 @@ def create_app():
     app.register_blueprint(dashboard_bp)
 
     return app
+
+
+def _run_migrations(app):
+    """Self-contained startup migration — checks for missing columns and adds them.
+    Safe to run repeatedly; does nothing if columns already exist."""
+    from sqlalchemy import text, inspect
+    with app.app_context():
+        inspector = inspect(db.engine)
+        cols = [c['name'] for c in inspector.get_columns('project')]
+        if 'image_path' not in cols:
+            with db.engine.connect() as conn:
+                conn.execute(text('ALTER TABLE project ADD COLUMN image_path VARCHAR(500)'))
+                conn.commit()

--- a/web/models.py
+++ b/web/models.py
@@ -26,8 +26,11 @@ class Project(db.Model):
     
     # Path to the raw trial file stored efficiently on the persistent cloud volume, bypassing SQL limits
     file_path = db.Column(db.String(500), nullable=False)
-    
+
+    # Path to the paired stimulus image (optional — NULL means no image uploaded)
+    image_path = db.Column(db.String(500), nullable=True)
+
     # State flags tracking processing
     is_demo = db.Column(db.Boolean, default=False)
-    
+
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)

--- a/web/routes/dashboard.py
+++ b/web/routes/dashboard.py
@@ -33,7 +33,9 @@ def get_projects():
     return jsonify([{
         "id": p.id,
         "name": p.name,
-        "is_demo": p.is_demo
+        "is_demo": p.is_demo,
+        "has_image": bool(p.image_path),
+        "image_name": os.path.basename(p.image_path) if p.image_path else None
     } for p in projects])
 
 @dashboard_bp.route('/api/projects/<int:project_id>/load', methods=['POST'])
@@ -81,6 +83,22 @@ def load_project(project_id):
         
         engine.eye_events = eye_events
         engine.trial_path = file_path
+
+        # Auto-load the paired stimulus image if one exists
+        if project.image_path:
+            storage_path = os.environ.get('STORAGE_PATH', os.path.join(os.path.dirname(__file__), '..', 'uploads'))
+            img_full_path = os.path.abspath(os.path.join(storage_path, project.image_path))
+            if os.path.exists(img_full_path):
+                engine.image_file_path = img_full_path
+            else:
+                engine.image_file_path = None   # file missing, don't crash
+        elif project.is_demo:
+            # Demo projects use the bundled stimulus image
+            engine.image_file_path = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), '..', 'static', 'demo_data', 'demo_image.png')
+            )
+        else:
+            engine.image_file_path = None
         
         return jsonify({"message": f"Project {project.name} loaded successfully."})
     except Exception as e:
@@ -95,9 +113,16 @@ def delete_project(project_id):
 
     if not project.is_demo:
         storage_path = os.environ.get('STORAGE_PATH', os.path.join(os.path.dirname(__file__), '..', 'uploads'))
-        file_path = os.path.join(storage_path, project.file_path)
-        if os.path.exists(file_path):
-            os.remove(file_path)
+        # Delete trial file
+        if project.file_path:
+            trial_path = os.path.join(storage_path, project.file_path)
+            if os.path.exists(trial_path):
+                os.remove(trial_path)
+        # Delete image file
+        if project.image_path:
+            img_path = os.path.join(storage_path, project.image_path)
+            if os.path.exists(img_path):
+                os.remove(img_path)
 
     db.session.delete(project)
     db.session.commit()
@@ -124,10 +149,22 @@ def upload_file():
     
     save_path = os.path.join(storage_path, unique_filename)
     file.save(save_path)
+
+    # Handle optional stimulus image
+    unique_image_name = None
+    if 'image' in request.files:
+        image = request.files['image']
+        if image.filename and image.filename != '':
+            img_ext = os.path.splitext(image.filename)[1].lower()
+            if img_ext in ('.png', '.jpg', '.jpeg'):
+                img_filename = secure_filename(image.filename)
+                unique_image_name = f"{current_user.id}_{uuid.uuid4().hex[:8]}_{img_filename}"
+                image.save(os.path.join(storage_path, unique_image_name))
     
     project = Project(
         name=filename,
         file_path=unique_filename,
+        image_path=unique_image_name,
         is_demo=False,
         user_id=current_user.id
     )
@@ -139,6 +176,8 @@ def upload_file():
         "project": {
             "id": project.id,
             "name": project.name,
-            "is_demo": project.is_demo
+            "is_demo": project.is_demo,
+            "has_image": bool(unique_image_name),
+            "image_name": os.path.basename(unique_image_name) if unique_image_name else None
         }
     })

--- a/web/static/dashboard.html
+++ b/web/static/dashboard.html
@@ -164,6 +164,42 @@
             color: var(--text-muted);
             font-size: 0.85rem;
         }
+
+        .staged-files {
+            display: flex;
+            gap: 12px;
+            justify-content: center;
+            margin-top: 12px;
+            flex-wrap: wrap;
+        }
+        .staged-file {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 8px;
+            font-size: 0.8rem;
+            font-weight: 600;
+        }
+        .staged-file.trial { background: rgba(56, 189, 248, 0.15); color: #7dd3fc; }
+        .staged-file.image { background: rgba(129, 140, 248, 0.15); color: #a5b4fc; }
+        .staged-file .remove-staged {
+            cursor: pointer; opacity: 0.6; font-size: 0.9rem;
+        }
+        .staged-file .remove-staged:hover { opacity: 1; }
+
+        .image-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-top: 8px;
+        }
+        .image-badge.has-image { background: rgba(129, 140, 248, 0.2); color: #a5b4fc; }
+        .image-badge.no-image { background: rgba(251, 191, 36, 0.15); color: #fbbf24; }
     </style>
 </head>
 <body>
@@ -174,10 +210,12 @@
         </div>
 
         <div class="upload-zone" id="upload-zone">
-            <input type="file" id="file-input" accept=".json,.asc" style="display: none;">
-            <p>Drag and drop trial data here</p>
-            <span>Supports .json and .asc files</span>
+            <input type="file" id="file-input" accept=".json,.asc,.png,.jpg,.jpeg" multiple style="display: none;">
+            <p>Drop trial + stimulus image here</p>
+            <span>Trial: .json / .asc &nbsp;·&nbsp; Image: .png / .jpg (optional)</span>
+            <div class="staged-files" id="staged-files"></div>
             <div id="upload-progress" style="margin-top: 10px; color: var(--accent-secondary); display: none;">Uploading...</div>
+            <button class="btn btn-primary" id="upload-btn" style="margin-top: 12px; width: auto; padding: 8px 24px; display: none;">Upload</button>
         </div>
 
         <div id="empty-state">
@@ -225,6 +263,9 @@
                     <div class="project-title">${p.name}</div>
                     <div class="project-meta">ID: ${p.id}</div>
                     ${p.is_demo ? '<div class="badge">Demo Dataset</div>' : ''}
+                    ${p.has_image
+                        ? `<div class="image-badge has-image">🖼 ${p.image_name}</div>`
+                        : '<div class="image-badge no-image">⚠ No stimulus image</div>'}
                 `;
 
                 card.querySelector('.delete-btn').addEventListener('click', async (e) => {
@@ -264,12 +305,54 @@
                 }
             }
 
-            // Drag and Drop Upload Logic
+            // Drag and Drop Upload Logic — auto-sorts files by type
             const uploadZone = document.getElementById('upload-zone');
             const fileInput = document.getElementById('file-input');
             const uploadProgress = document.getElementById('upload-progress');
+            const stagedFilesEl = document.getElementById('staged-files');
+            const uploadBtn = document.getElementById('upload-btn');
+            let stagedTrial = null;
+            let stagedImage = null;
 
-            uploadZone.addEventListener('click', () => fileInput.click());
+            const TRIAL_EXTS = ['.json', '.asc'];
+            const IMAGE_EXTS = ['.png', '.jpg', '.jpeg'];
+
+            function getExt(name) { return '.' + name.split('.').pop().toLowerCase(); }
+
+            function stageFiles(files) {
+                for (const f of files) {
+                    const ext = getExt(f.name);
+                    if (TRIAL_EXTS.includes(ext)) stagedTrial = f;
+                    else if (IMAGE_EXTS.includes(ext)) stagedImage = f;
+                    else alert(`Unsupported file type: ${f.name}`);
+                }
+                renderStaged();
+            }
+
+            function renderStaged() {
+                stagedFilesEl.innerHTML = '';
+                if (stagedTrial) {
+                    stagedFilesEl.innerHTML += `<span class="staged-file trial">📄 ${stagedTrial.name} <span class="remove-staged" data-type="trial">✕</span></span>`;
+                }
+                if (stagedImage) {
+                    stagedFilesEl.innerHTML += `<span class="staged-file image">🖼 ${stagedImage.name} <span class="remove-staged" data-type="image">✕</span></span>`;
+                }
+                uploadBtn.style.display = stagedTrial ? 'inline-flex' : 'none';
+                // wire remove buttons
+                stagedFilesEl.querySelectorAll('.remove-staged').forEach(btn => {
+                    btn.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        if (btn.dataset.type === 'trial') stagedTrial = null;
+                        else stagedImage = null;
+                        renderStaged();
+                    });
+                });
+            }
+
+            uploadZone.addEventListener('click', (e) => {
+                if (e.target === uploadBtn || e.target.closest('.remove-staged')) return;
+                fileInput.click();
+            });
 
             uploadZone.addEventListener('dragover', (e) => {
                 e.preventDefault();
@@ -283,56 +366,54 @@
             uploadZone.addEventListener('drop', (e) => {
                 e.preventDefault();
                 uploadZone.classList.remove('dragover');
-                if (e.dataTransfer.files.length) {
-                    handleUpload(e.dataTransfer.files[0]);
-                }
+                if (e.dataTransfer.files.length) stageFiles(e.dataTransfer.files);
             });
 
             fileInput.addEventListener('change', (e) => {
-                if (e.target.files.length) {
-                    handleUpload(e.target.files[0]);
-                }
+                if (e.target.files.length) stageFiles(e.target.files);
+                fileInput.value = '';
             });
 
-            async function handleUpload(file) {
-                if (!file.name.endsWith('.json') && !file.name.endsWith('.asc')) {
-                    alert('Only .json and .asc files are currently supported.');
-                    return;
-                }
-                
+            uploadBtn.addEventListener('click', async (e) => {
+                e.stopPropagation();
+                if (!stagedTrial) return;
+
                 uploadProgress.style.display = 'block';
-                uploadProgress.innerText = `Uploading ${file.name}...`;
-                uploadZone.style.pointerEvents = 'none';
+                uploadProgress.innerText = `Uploading ${stagedTrial.name}${stagedImage ? ' + ' + stagedImage.name : ''}...`;
+                uploadBtn.disabled = true;
 
                 const formData = new FormData();
-                formData.append('file', file);
+                formData.append('file', stagedTrial);
+                if (stagedImage) formData.append('image', stagedImage);
 
                 try {
                     const res = await fetch('/api/upload', {
                         method: 'POST',
                         body: formData
                     });
-                    
+
                     if (!res.ok) {
                         const err = await res.json();
                         throw new Error(err.error || 'Upload failed');
                     }
-                    
+
                     const newProject = await res.json();
                     emptyState.style.display = 'none';
                     addProjectCard(newProject.project);
-                    
+
                     uploadProgress.innerText = 'Upload successful!';
                     setTimeout(() => { uploadProgress.style.display = 'none'; }, 3000);
+                    stagedTrial = null;
+                    stagedImage = null;
+                    renderStaged();
                 } catch (err) {
                     console.error(err);
                     alert('Upload Error: ' + err.message);
                     uploadProgress.style.display = 'none';
                 } finally {
-                    uploadZone.style.pointerEvents = 'all';
-                    fileInput.value = ''; // clear input
+                    uploadBtn.disabled = false;
                 }
-            }
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
### Description
This PR implements the ability to permanently pair stimulus images with their corresponding trial datasets, resolving the issue of lost images between sessions or server restarts.

### Changes Made
- **Database**: Added a nullable `image_path` column to the `Project` model.
- **Migrations**: Implemented a self-contained startup migration in `__init__.py` to safely execute `ALTER TABLE` on existing databases (compatible with both local SQLite and production PostgreSQL).
- **Backend API (`dashboard.py`)**:
  - `POST /api/upload`: Now accepts a multipart form with an optional `image` payload, saves both files to the persistent volume, and links them in the database.
  - `POST /api/projects/<id>/load`: Automatically resolves and loads the paired stimulus image into the engine session.
  - `DELETE /api/projects/<id>`: Safely garbage-collects both the trial and image files from storage.
- **Frontend UI (`dashboard.html`)**:
  - Upgraded the drag-and-drop zone to support multi-file staging with automatic type detection.
  - Added visual pills for staged files and deferred the actual upload until the user clicks 'Upload'.
  - Project cards now display a badge indicating whether a stimulus image is attached.

Resolves #59
