### PR TITLE
fix: Preserve None in suggested_corrections snapshot to prevent Numpy crash on undo

### DIFF
--- a/src/state.py
+++ b/src/state.py
@@ -28,7 +28,7 @@ class Fix8State:
             self.eye_events = eye_events.copy()
 
         if suggested_corrections is None:
-            self.suggested_corrections = []
+            self.suggested_corrections = None
         else:
             self.suggested_corrections = suggested_corrections.copy()
 


### PR DESCRIPTION
Fixes a type-coercion bug in the `Fix8State` Memento snapshot. When no suggestions exist (e.g. before running a correction), the engine state has `suggested_corrections = None`. The snapshot was mistakenly coercing this into an empty Python list `[]`.

When clicking 'Undo', this empty list was restored back into the engine. The backend renderer uses an `is not None` guard before attempting 2D Numpy slicing (e.g., `sug[:, 0]`), which fails to catch the empty list and triggers a fatal `TypeError`, crashing the canvas load. 

Changing the snapshot logic to properly preserve `None` fixes this.