### PR TITLE
fix: Reset all engine state before loading a new project

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -45,6 +45,25 @@ class Fix8Core:
         self.aoi_width = 7
         self.aoi_height = 4
 
+    def reset_session_state(self):
+        """Clear all mutable session state before loading a new trial.
+        Prevents stale AOIs, suggestions, undo history, and cursor positions
+        from bleeding across project loads."""
+        self.eye_events = None
+        self.current_fixation = -1
+        self.suggested_corrections = None
+        self.state_history = History()
+        self.aoi = None
+        self.selected_fixation = None
+        self.suggested_fixation = None
+        self.image_file_path = None
+        self.trial_path = None
+        self.trial_name = None
+        self.algorithm = "manual"
+        self.algorithm_function = None
+        self.secondary_algorithm_function = None
+        self.metadata = ""
+
     def previous_fixation(self):
         if self.current_fixation > 0:
             self.current_fixation -= 1

--- a/web/routes/api.py
+++ b/web/routes/api.py
@@ -148,6 +148,7 @@ def api_reset():
 @api_bp.route("/load_demo", methods=["POST"])
 def api_load_demo():
     engine = get_engine()
+    engine.reset_session_state()
     demo_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static", "demo_data", "demo_trial.json"))
     if not os.path.exists(demo_path):
         return jsonify({"error": f"Demo file not found at {demo_path}"}), 404

--- a/web/routes/dashboard.py
+++ b/web/routes/dashboard.py
@@ -49,7 +49,8 @@ def load_project(project_id):
     import pandas as pd
     
     engine = get_engine()
-    
+    engine.reset_session_state()
+
     if project.is_demo:
         file_path = os.path.join(os.path.dirname(__file__), '..', 'static', 'demo_data', 'demo_trial.json')
     else:


### PR DESCRIPTION
### Description
Fixes stale engine state bleeding across project loads. When switching projects from the dashboard, attributes like AOIs, suggestions, undo history, and cursor positions were persisting from the previous project, causing visual artifacts and potential crashes.

### Changes Made
- **`src/core.py`**: Added `reset_session_state()` method to `Fix8Core` that defensively clears all 14 mutable session attributes back to their initial values (AOIs, suggestions, undo stack, cursor positions, algorithm selection, image path, etc.)
- **`web/routes/dashboard.py`**: Call `engine.reset_session_state()` in `load_project()` before loading new trial data
- **`web/routes/api.py`**: Call `engine.reset_session_state()` in `api_load_demo()` before loading demo data

### Why a Single Method
Having one canonical reset point means future attributes added to `Fix8Core` only need to be cleared in one place. Both load paths (`load_project` and `api_load_demo`) call the same method, eliminating the risk of one path forgetting to clear something.

Resolves #61
