### PR TITLE
feat: Live ghost dot drag preview with native drag prevention

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -298,6 +298,23 @@ input[type=range]::-webkit-slider-runnable-track {
   border-radius: 4px;
   max-width: 100%;
   height: auto;
+  -webkit-user-drag: none;
+  user-select: none;
+  -webkit-user-select: none;
+  pointer-events: auto;
+}
+
+#drag-ghost {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgba(240, 69, 69, 0.65);
+  border: 2px solid rgba(219, 38, 38, 0.9);
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  z-index: 10;
+  display: none;
 }
 
 #empty-state {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -84,7 +84,7 @@
 
         <div class="canvas-container" id="canvas-container">
             <div id="interactive-grid">
-                <img id="engine-render" alt="Fix8 Rendering">
+                <img id="engine-render" alt="Fix8 Rendering" draggable="false">
                 <div id="tooltip"></div>
             </div>
             <div id="empty-state">

--- a/web/static/js/visualizer.js
+++ b/web/static/js/visualizer.js
@@ -4,7 +4,8 @@
  *   - mapping mouse coords to image-space
  *   - detecting which fixation is being hovered
  *   - tooltip display
- *   - drag-and-drop to send updates via onFixationUpdate
+ *   - live drag preview via a DOM ghost dot
+ *   - drag-and-drop commit via onFixationUpdate (sent on mouseup)
  * Rendering refresh is owned by app.js.
  */
 class Fix8Visualizer {
@@ -12,6 +13,11 @@ class Fix8Visualizer {
         this.img = document.getElementById("engine-render");
         this.grid = document.getElementById("interactive-grid");
         this.tooltip = document.getElementById("tooltip");
+
+        // Create the ghost dot used for live drag preview
+        this.ghostDot = document.createElement("div");
+        this.ghostDot.id = "drag-ghost";
+        this.grid.appendChild(this.ghostDot);
 
         this.fixations = [];
         this.hoveredIndex = -1;
@@ -44,11 +50,20 @@ class Fix8Visualizer {
         };
     }
 
+    _positionGhost(e) {
+        const gridRect = this.grid.getBoundingClientRect();
+        this.ghostDot.style.left = (e.clientX - gridRect.left) + "px";
+        this.ghostDot.style.top = (e.clientY - gridRect.top) + "px";
+    }
+
     _setupEvents() {
-        this.grid.addEventListener("mousedown", () => {
+        this.grid.addEventListener("mousedown", (e) => {
             if (this.hoveredIndex !== -1) {
+                e.preventDefault(); // belt-and-suspenders: stop any residual native drag
                 this.isDragging = true;
                 this.draggedIndex = this.hoveredIndex;
+                this._positionGhost(e);
+                this.ghostDot.style.display = "block";
             }
         });
 
@@ -59,6 +74,7 @@ class Fix8Visualizer {
             if (this.isDragging && this.draggedIndex !== -1) {
                 this.fixations[this.draggedIndex].x_cord = pos.x;
                 this.fixations[this.draggedIndex].y_cord = pos.y;
+                this._positionGhost(e);
                 this.tooltip.style.opacity = "0";
                 this.grid.style.cursor = "grabbing";
                 return;
@@ -104,6 +120,7 @@ class Fix8Visualizer {
             }
             this.isDragging = false;
             this.draggedIndex = -1;
+            this.ghostDot.style.display = "none";
             this.grid.style.cursor = "crosshair";
         };
 


### PR DESCRIPTION
### Description
Implements a live drag preview using a DOM ghost dot, replacing the browser's default drag thumbnail behavior. When a user clicks and drags a fixation dot, a red circle styled to match the Matplotlib-rendered fixation dots follows the cursor in real time. On release, the backend receives the new coordinates, re-renders the canvas, and the ghost disappears.

### The Problem
The `<img>` element triggers the browser's native HTML5 drag behavior, which attaches a tiny thumbnail of the entire canvas to the cursor during drag. This is distracting and provides no useful spatial feedback.

### Changes Made
- **`web/static/index.html`**: Added `draggable="false"` to the `<img id="engine-render">` element to disable native drag at the HTML level.
- **`web/static/css/style.css`**: Added `-webkit-user-drag: none` and `user-select: none` to `#engine-render` as belt-and-suspenders prevention. Defined `#drag-ghost` — a 16×16 red circle with matching border, absolutely positioned within the grid overlay.
- **`web/static/js/visualizer.js`**: 
  - Constructor now creates and appends a `#drag-ghost` div to the interactive grid
  - New `_positionGhost(e)` helper maps viewport coordinates to grid-relative positioning
  - `mousedown` handler calls `e.preventDefault()`, shows the ghost, and begins tracking
  - `mousemove` during drag repositions the ghost in real time
  - `commit()` (mouseup/mouseleave) hides the ghost and fires the existing `onFixationUpdate` callback

### Undo Support
No backend changes needed — `Fix8Core.update_fixation()` already calls `save_state()` before modifying coordinates, so every drag automatically becomes one entry on the undo stack.

Resolves #63
